### PR TITLE
fix: stop progress label bg from blocking progress bar

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -58,7 +58,7 @@ sep_left = { open = "", close = "" }
 sep_right = { open = "", close = "" }
 overall = { fg = "#c8c093", bg = "#16161d" }
 
-progress_label = { fg = "#7e9cd8", bg = "#2a2a37", bold = true }
+progress_label = { fg = "#7e9cd8", bold = true }
 progress_normal = { fg = "#2a2a37", bg = "#1f1f28" }
 progress_error = { fg = "#2a2a37", bg = "#1f1f28" }
 


### PR DESCRIPTION
Removes the bg from the progress bar label. Currently, it's set to the same colour as the progress bar meter, and covers it up when it is behind the text.

Before:

<img width="207" height="76" alt="screenshot_2025-08-02-183739" src="https://github.com/user-attachments/assets/8ff969ea-cf18-4664-bf5c-e24de79c906b" /> <img width="207" height="76" alt="screenshot_2025-08-02-180225" src="https://github.com/user-attachments/assets/2de0585d-9301-4a38-a07a-94ed9d7003e8" />

After:

<img width="207" height="76" alt="screenshot_2025-08-02-183835" src="https://github.com/user-attachments/assets/db6accdc-4e85-4c8d-8fd7-e848589cf8df" /> <img width="207" height="76" alt="screenshot_2025-08-02-180115" src="https://github.com/user-attachments/assets/f2b3d92d-2a02-40d7-a6ca-4653bb5ab3d7" />
