### PR TITLE
chore: rename manager to mgr, use redesigned tab options (+ a question)

### DIFF
--- a/flavor.toml
+++ b/flavor.toml
@@ -19,7 +19,7 @@
 # surimiOrange  "#ffa066"
 # waveAqua2     "#7aa89f"
 
-[manager]
+[mgr]
 marker_copied = { fg = "#98bb6c", bg = "#98bb6c" }
 marker_cut = { fg = "#e46876", bg = "#e46876" }
 marker_marked = { fg = "#957fb8", bg = "#957fb8" }
@@ -32,16 +32,19 @@ preview_hovered = { reversed = true }
 find_keyword = { fg = "#ffa066", bg = "#1f1f28" }
 find_position = {}
 
-tab_active = { reversed = true }
-tab_inactive = {}
-tab_width = 1
-
 count_copied = { fg = "#1f1f28", bg = "#98bb6c" }
 count_cut = { fg = "#1f1f28", bg = "#e46876" }
 count_selected = { fg = "#1f1f28", bg = "#e6c384" }
 
 border_symbol = "│"
 border_style = { fg = "#dcd7ba" }
+
+[tabs]
+active = { fg = "#1f1f28", bg = "#7e9cd8", bold = true }
+inactive = { fg = "#7e9cd8", bg = "#2a2a37" }
+
+sep_inner = { open = "", close = "" }
+sep_outer = { open = "", close = "" }
 
 
 [mode]

--- a/flavor.toml
+++ b/flavor.toml
@@ -34,13 +34,13 @@ find_position = {}
 
 count_copied = { fg = "#1f1f28", bg = "#98bb6c" }
 count_cut = { fg = "#1f1f28", bg = "#e46876" }
-count_selected = { fg = "#1f1f28", bg = "#e6c384" }
+count_selected = { fg = "#1f1f28", bg = "#ffa066" }
 
 border_symbol = "│"
 border_style = { fg = "#dcd7ba" }
 
 [tabs]
-active = { fg = "#1f1f28", bg = "#7e9cd8", bold = true }
+active = { fg = "#1f1f28", bg = "#7e9cd8" }
 inactive = { fg = "#7e9cd8", bg = "#2a2a37" }
 
 sep_inner = { open = "", close = "" }


### PR DESCRIPTION
This pull renames [manager] to [mgr] to match the new flavor spec, and uses the new options from the tab redesign.

I'm not sure what the tabs looked like before, or what they should look like in this theme, so I guessed. Feel free to give feedback, or adjust it to what fits your design. Here's what they look like now:

<img width="326" height="93" alt="screenshot_2025-08-07-193631" src="https://github.com/user-attachments/assets/41ee140f-4034-48b5-9645-361779f6b781" />

I also noticed that marker_selected and count_selected use different colours. Should they match? And if yes, which colour is "correct"? I can include that in this pr too if you want.

<img width="214" height="81" alt="screenshot_2025-08-07-193650" src="https://github.com/user-attachments/assets/9a9d6c0c-37c6-436a-bb3e-18877153ee0b" /> 
<img width="108" height="55" alt="screenshot_2025-08-07-193658" src="https://github.com/user-attachments/assets/97edb4a2-7db0-477e-a681-9f00197dd404" />
